### PR TITLE
Add local storage persistence for habits

### DIFF
--- a/src/hooks/useHabits.ts
+++ b/src/hooks/useHabits.ts
@@ -1,0 +1,132 @@
+import { useState, useEffect } from 'react';
+import useLocalStorage from './useLocalStorage';
+import type { Habit } from '@/pages/Index';
+
+// Default habits to show when the app is first used
+const defaultHabits: Habit[] = [
+  {
+    id: "1",
+    name: "Drink Water",
+    icon: "💧",
+    color: "from-blue-400 to-cyan-400",
+    streak: 0,
+    completedToday: false,
+    totalCompleted: 0,
+    createdAt: new Date(),
+    image: "/3d-rendering-young-tiger.jpg",
+  },
+  {
+    id: "2",
+    name: "Exercise",
+    icon: "💪",
+    color: "from-orange-400 to-red-400",
+    streak: 0,
+    completedToday: false,
+    totalCompleted: 0,
+    createdAt: new Date(),
+    image: "/cartoon-animated-penguin-with-headphones.jpg",
+  },
+  {
+    id: "3",
+    name: "Read Books",
+    icon: "📚",
+    color: "from-purple-400 to-pink-400",
+    streak: 0,
+    completedToday: false,
+    totalCompleted: 0,
+    createdAt: new Date(),
+  },
+];
+
+// Function to check if it's a new day compared to the last saved date
+const isNewDay = (lastSavedDate: string | null): boolean => {
+  if (!lastSavedDate) return false;
+  
+  const today = new Date();
+  const lastDate = new Date(lastSavedDate);
+  
+  return (
+    today.getFullYear() !== lastDate.getFullYear() ||
+    today.getMonth() !== lastDate.getMonth() ||
+    today.getDate() !== lastDate.getDate()
+  );
+};
+
+export const useHabits = () => {
+  // Use our custom localStorage hook to persist habits
+  const [habits, setHabits] = useLocalStorage<Habit[]>('habits', defaultHabits);
+  
+  // Also track the last date habits were accessed
+  const [lastSavedDate, setLastSavedDate] = useLocalStorage<string | null>(
+    'lastSavedDate', 
+    null
+  );
+
+  // Check for day change when component mounts
+  useEffect(() => {
+    // If it's a new day, reset all habits to not completed
+    if (isNewDay(lastSavedDate)) {
+      setHabits(prevHabits => 
+        prevHabits.map(habit => ({
+          ...habit,
+          completedToday: false
+        }))
+      );
+    }
+    
+    // Update the last saved date to today
+    setLastSavedDate(new Date().toISOString());
+  }, [lastSavedDate, setHabits, setLastSavedDate]);
+
+  // Toggle a habit's completion status
+  const toggleHabit = (id: string) => {
+    setHabits(prev => prev.map(habit => {
+      if (habit.id === id) {
+        const wasCompleted = habit.completedToday;
+        return {
+          ...habit,
+          completedToday: !wasCompleted,
+          streak: !wasCompleted ? habit.streak + 1 : Math.max(0, habit.streak - 1),
+          totalCompleted: !wasCompleted ? habit.totalCompleted + 1 : Math.max(0, habit.totalCompleted - 1),
+        };
+      }
+      return habit;
+    }));
+  };
+
+  // Add a new habit
+  const addHabit = (habit: Omit<Habit, "id" | "streak" | "completedToday" | "totalCompleted" | "createdAt">) => {
+    const newHabit: Habit = {
+      ...habit,
+      id: Date.now().toString(),
+      streak: 0,
+      completedToday: false,
+      totalCompleted: 0,
+      createdAt: new Date(),
+    };
+    setHabits(prev => [...prev, newHabit]);
+  };
+
+  // Delete a habit
+  const deleteHabit = (id: string) => {
+    setHabits(prev => prev.filter(habit => habit.id !== id));
+  };
+
+  // Calculate stats
+  const stats = {
+    completedToday: habits.filter(h => h.completedToday).length,
+    totalHabits: habits.length,
+    totalStreak: habits.reduce((sum, h) => sum + h.streak, 0),
+    bestStreak: Math.max(...habits.map(h => h.streak), 0),
+  };
+
+  return {
+    habits,
+    toggleHabit,
+    addHabit,
+    deleteHabit,
+    stats,
+  };
+};
+
+export default useHabits;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+
+// Custom hook for managing state with localStorage
+function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] {
+  // Get from local storage then parse stored json or return initialValue
+  const readValue = (): T => {
+    // Prevent build error "window is undefined" but keep working
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${key}":`, error);
+      return initialValue;
+    }
+  };
+
+  // State to store our value
+  const [storedValue, setStoredValue] = useState<T>(readValue);
+
+  // Return a wrapped version of useState's setter function that persists the new value to localStorage
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have the same API as useState
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      
+      // Save state
+      setStoredValue(valueToStore);
+      
+      // Save to local storage
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      console.warn(`Error setting localStorage key "${key}":`, error);
+    }
+  };
+
+  // Listen for changes to this localStorage key in other tabs/windows
+  useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === key && event.newValue) {
+        setStoredValue(JSON.parse(event.newValue));
+      }
+    };
+    
+    // Listen for storage events
+    window.addEventListener('storage', handleStorageChange);
+    
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, [key]);
+
+  return [storedValue, setValue];
+}
+
+export default useLocalStorage;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,12 @@
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Plus, Flame, Target, Calendar, TrendingUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import HabitCard from "@/components/HabitCard";
 import AddHabitModal from "@/components/AddHabitModal";
 import StatsCard from "@/components/StatsCard";
+import { useHabits } from "@/hooks/useHabits";
 
 export interface Habit {
   id: string;
@@ -20,73 +21,13 @@ export interface Habit {
 }
 
 const Index = () => {
-  const [habits, setHabits] = useState<Habit[]>([
-    {
-      id: "1",
-      name: "Drink Water",
-      icon: "💧",
-      color: "from-blue-400 to-cyan-400",
-      streak: 0,
-      completedToday: false,
-      totalCompleted: 0,
-      createdAt: new Date(),
-      image: "/3d-rendering-young-tiger.jpg",
-    },
-    {
-      id: "2",
-      name: "Exercise",
-      icon: "💪",
-      color: "from-orange-400 to-red-400",
-      streak: 0,
-      completedToday: false,
-      totalCompleted: 0,
-      createdAt: new Date(),
-      image: "/cartoon-animated-penguin-with-headphones.jpg",
-    },
-    {
-      id: "3",
-      name: "Read Books",
-      icon: "📚",
-      color: "from-purple-400 to-pink-400",
-      streak: 0,
-      completedToday: false,
-      totalCompleted: 0,
-      createdAt: new Date(),
-    },
-  ]);
-  
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-
-  const toggleHabit = (id: string) => {
-    setHabits(prev => prev.map(habit => {
-      if (habit.id === id) {
-        const wasCompleted = habit.completedToday;
-        return {
-          ...habit,
-          completedToday: !wasCompleted,
-          streak: !wasCompleted ? habit.streak + 1 : Math.max(0, habit.streak - 1),
-          totalCompleted: !wasCompleted ? habit.totalCompleted + 1 : habit.totalCompleted - 1,
-        };
-      }
-      return habit;
-    }));
-  };
-
-  const addHabit = (habit: Omit<Habit, "id" | "streak" | "completedToday" | "totalCompleted" | "createdAt">) => {
-    const newHabit: Habit = {
-      ...habit,
-      id: Date.now().toString(),
-      streak: 0,
-      completedToday: false,
-      totalCompleted: 0,
-      createdAt: new Date(),
-    };
-    setHabits(prev => [...prev, newHabit]);
-  };
-
-  const completedToday = habits.filter(h => h.completedToday).length;
-  const totalStreak = habits.reduce((sum, h) => sum + h.streak, 0);
-  const bestStreak = Math.max(...habits.map(h => h.streak), 0);
+  
+  // Use our custom hook for habit management with local storage
+  const { habits, toggleHabit, addHabit, stats } = useHabits();
+  
+  // Destructure stats for easier access
+  const { completedToday, totalHabits, totalStreak, bestStreak } = stats;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 relative overflow-hidden">
@@ -252,7 +193,7 @@ const Index = () => {
           <StatsCard
             icon={<Target className="h-5 w-5" />}
             label="Today"
-            value={`${completedToday}/${habits.length}`}
+            value={`${completedToday}/${totalHabits}`}
             gradient="from-green-400 to-emerald-400"
           />
           <StatsCard
@@ -273,7 +214,7 @@ const Index = () => {
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-gray-800">Your Habits</h2>
-            <span className="text-sm text-gray-500">{habits.length} habits</span>
+            <span className="text-sm text-gray-500">{totalHabits} habits</span>
           </div>
           
           {habits.map((habit, index) => (


### PR DESCRIPTION
## Implemented Local Storage Functionality for Habit Persistence

I’ve implemented local storage functionality to persist habit data between sessions. This means users won’t lose their habits when they refresh the page or close the browser.

### ✅ What I Did

- **Created a generic `useLocalStorage` hook**
  - Allows storing any type of data in the browser's local storage

- **Created a specialized `useHabits` hook** that:
  - Manages habit data with local storage
  - Handles day changes by resetting completion status daily
  - Provides utility functions to:
    - Toggle habit completion
    - Add new habits
    - Delete existing habits
  - Calculates habit statistics for the dashboard

- **Updated `Index.tsx`**
  - Integrated the new `useHabits` and `useLocalStorage` hooks

### 🎯 Benefits of These Changes

- User data **persists between sessions**
- Habit completion status **resets automatically each day**
- **Separation of concerns** makes the codebase more modular
- Improved **maintainability** for adding future features
